### PR TITLE
Switch to C++23 and CMake 25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 FROM gcc:12.2
 
 # Install
-RUN apt update -y && apt upgrade -y && apt install cmake -y
+RUN apt update -y && apt upgrade -y
+RUN apt-get install build-essential
+
+RUN wget https://cmake.org/files/v3.25/cmake-3.25.0.tar.gz
+RUN tar xf cmake-3.25.0.tar.gz
+RUN cd cmake-3.25.0 && ./configure && make && make install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.13)  # CMake version check
+cmake_minimum_required(VERSION 3.20)  # CMake version check
 project(swann)                        # Create project "swann"
-set(CMAKE_CXX_STANDARD 20)            # Enable c++20 standard
+set(CMAKE_CXX_STANDARD 23)            # Enable c++23 standard
 
 # Add main.cpp file of project root directory as source file
 file( GLOB SOURCE_FILES


### PR DESCRIPTION
Closes #11 by switching to C++23, and installing CMake 25 manually.

`CMAKE_CXX_STANDARD 23` requires CMake 3.20 or newer, and `apt install cmake -y` installs version 3.18.4, so I've opted to manually download and install CMake 25. However, it takes ~13 minutes to build the Docker image now.

Maybe you can come up with a faster solution?