### PR TITLE
Feature/threaded rebuilding

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run tests
-        run: docker compose up test
+        run: docker compose run test

--- a/benchmark/benchmark-1689083546.csv
+++ b/benchmark/benchmark-1689083546.csv
@@ -1,0 +1,11 @@
+2023-07-11T13:52:26+00:00
+Running /swann/build/benchmark
+Run on (4 X 2304 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 6144 KiB (x1)
+Load Average: 0.85, 0.57, 0.49
+name,iterations,real_time,cpu_time,time_unit,bytes_per_second,items_per_second,label,error_occurred,error_message,"P1","P2","foundPerQuery","inputRecall","kNN","optimizationSteps","recall","slowestQuery","timePerQuery","trie_count","trie_depth"
+"QueryXPointsLSHForest/0/10/90/850/500/manual_time",1,63539.7,63486.9,ms,,,,,,0.85,0.5,11238.4,0.9,10,8,0.92876,0.0798772,0.00635397,16,17

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,7 @@ add_executable(
   "test/index/lshforest.cc"
   "test/index/bfindex.cc"
   "test/index/lshtrie.cc"
+  "test/index/lshmapprioqueue.cc"
 )
 
 target_link_libraries(

--- a/src/benchmark/dataset_benchmark.cc
+++ b/src/benchmark/dataset_benchmark.cc
@@ -104,7 +104,7 @@ static void BM_query_x_points_LSHForest(benchmark::State &state)
             << "Count: " << count << std::endl
             << "Points: " << dataset.points.size() << std::endl;
 
-  const ui32 optimization_steps = 20;
+  const ui32 optimization_steps = 5;
   auto maps = LSHMapFactory<D>::mthread_create_optimized(dataset.points, pool, depth, count, optimization_steps);
   // auto maps = LSHMapFactory<D>::create(pool, depth, count);
 

--- a/src/benchmark/dataset_benchmark.cc
+++ b/src/benchmark/dataset_benchmark.cc
@@ -110,7 +110,6 @@ static void BM_query_x_points_LSHForest(benchmark::State &state)
   auto maps = LSHMapFactory<D>::mthread_create_optimized(dataset.points, pool, depth, count, optimization_steps);
   // auto maps = LSHMapFactory<D>::create(pool, depth, count);
 
-
   std::cout << "Building index" << std::endl;
   LSHForest<D> *index = new LSHForest<D>(maps, dataset.points, SingleBitFailure<D>);
   index->build();

--- a/src/benchmark/dataset_benchmark.cc
+++ b/src/benchmark/dataset_benchmark.cc
@@ -104,7 +104,7 @@ static void BM_query_x_points_LSHForest(benchmark::State &state)
             << "Count: " << count << std::endl
             << "Points: " << dataset.points.size() << std::endl;
 
-  const ui32 optimization_steps = 5;
+  const ui32 optimization_steps = 10;
   auto maps = LSHMapFactory<D>::mthread_create_optimized(dataset.points, pool, depth, count, optimization_steps);
   // auto maps = LSHMapFactory<D>::create(pool, depth, count);
 
@@ -332,9 +332,8 @@ std::vector<int64_t> benchies[] = {
 BENCHMARK(BM_query_x_points_LSHForest)
   ->Name("QueryXPointsLSHForest")
   ->Unit(benchmark::kMillisecond)
-
-  // ->Args(benchies[0])
-  ->Args({1, 10, 90, 850, 500})
+  ->Args({2, 10, 90, 860, 535})
+  // ->Args({2, 10, 92, 860, 535})
   ->UseManualTime();
 //     // ->Args({0, 10, 90, 0, 1}) // XS - query for 10 points
 //     // ->Args({0, 10, 90, 0, 2}) // XS - query for 10 points

--- a/src/benchmark/dataset_benchmark.cc
+++ b/src/benchmark/dataset_benchmark.cc
@@ -107,7 +107,7 @@ static void BM_query_x_points_LSHForest(benchmark::State &state)
             << "Points: " << dataset.points.size() << std::endl;
 
   const ui32 optimization_steps = 8;
-  auto maps = LSHMapFactory<D>::create_optimized(dataset.points, pool, depth, count, optimization_steps);
+  auto maps = LSHMapFactory<D>::mthread_create_optimized(dataset.points, pool, depth, count, optimization_steps);
   // auto maps = LSHMapFactory<D>::create(pool, depth, count);
 
 

--- a/src/benchmark/dataset_benchmark.cc
+++ b/src/benchmark/dataset_benchmark.cc
@@ -88,8 +88,6 @@ static void BM_query_x_points_LSHForest(benchmark::State &state)
 
   std::cout << "Instantiating maps" << std::endl;
   
-
-
   const float P1 = state.range(3) / 1000.0;
   const float P2 = state.range(4) / 1000.0;
 
@@ -106,7 +104,7 @@ static void BM_query_x_points_LSHForest(benchmark::State &state)
             << "Count: " << count << std::endl
             << "Points: " << dataset.points.size() << std::endl;
 
-  const ui32 optimization_steps = 8;
+  const ui32 optimization_steps = 20;
   auto maps = LSHMapFactory<D>::mthread_create_optimized(dataset.points, pool, depth, count, optimization_steps);
   // auto maps = LSHMapFactory<D>::create(pool, depth, count);
 
@@ -335,8 +333,8 @@ BENCHMARK(BM_query_x_points_LSHForest)
   ->Name("QueryXPointsLSHForest")
   ->Unit(benchmark::kMillisecond)
 
-  ->Args(benchies[0])
-
+  // ->Args(benchies[0])
+  ->Args({1, 10, 90, 850, 500})
   ->UseManualTime();
 //     // ->Args({0, 10, 90, 0, 1}) // XS - query for 10 points
 //     // ->Args({0, 10, 90, 0, 2}) // XS - query for 10 points

--- a/src/index/lsharraymap.hpp
+++ b/src/index/lsharraymap.hpp
@@ -43,6 +43,16 @@ public:
     this->build(hf);
   }
 
+  ui32 maxBucketSize() {
+    ui32 max = 0;
+    for (const auto& b : this->buckets) {
+      if (b.size() > max) {
+        max = b.size();
+      }
+    }
+    return max;
+  }
+  
   /**
    * @brief Initialize this map with the given hashes. After this call, the map will be empty
    * @warning This will reset the map, and all points inserted will be lost

--- a/src/index/lshforest.hpp
+++ b/src/index/lshforest.hpp
@@ -29,6 +29,7 @@ public:
   ui32 stop_hdist;
   ui32 stop_mask_index;
   ui32 buckets_visited;
+  
   LSHForest(std::vector<LSHMap<D>*> &maps, std::vector<Point<D>> &input, QueryFailureProbability failure_strategy = DEFAULT_FAILURE) 
     : is_exit(failure_strategy), 
       depth(maps.empty() ? 0 : maps.front()->depth()), 

--- a/src/index/lshforest.hpp
+++ b/src/index/lshforest.hpp
@@ -69,7 +69,7 @@ public:
   inline float get_bucket_factor(const float recall) const noexcept {
     const float recall_factor = (1.0 - recall) / 0.05;
     const float val = (this->size() * (std::pow(recall,recall_factor-1))) / ((1000.0 + std::log2(this->maps.front()->bucketCount())) * this->maps.size()) + 40.0;
-    return 2 * val;
+    return 3 * val;
   }
 
   /**
@@ -87,9 +87,7 @@ public:
     PointMap<D> found(this->points, point, k);  // found : contains the k nearest points found so far and look up of seen points
      
     const ui32 M = this->maps.size(), BATCH_SIZE = k * this->get_bucket_factor(recall);
-    // std::cout << "Batch size: " << BATCH_SIZE << std::endl
-    //           << "Bucket factor: " << this->get_bucket_factor(recall) << std::endl
-    //           << "Bucket count: " << std::endl;
+
     std::vector<ui32> hash(M); // hash[m] : contains the hash of point in map[m]
     for (ui32 m = 0; m < M; ++m){
       hash[m] = this->maps[m]->hash(point);

--- a/src/index/lshhashmap.hpp
+++ b/src/index/lshhashmap.hpp
@@ -101,8 +101,6 @@ public:
     for (const auto& p : points) {
       this->add(p);
     }
-
-    // this->buckets.rehash(0);
   };
 
   /**

--- a/src/index/lshhashmap.hpp
+++ b/src/index/lshhashmap.hpp
@@ -22,9 +22,10 @@ public:
   // all possible masks by hamming distance 
   static inline std::vector<std::vector<ui32>> masks = std::vector<std::vector<ui32>>();
 
-  static void initMasks(ui32 depth) {
+  static void initMasks(ui32 depth = 32U, ui32 max_hdist = 4U) {
     ui32 constructed_masks = 0;
-    for (ui32 hdist = 0; hdist <= depth; ++hdist) {
+    if (max_hdist == 0) max_hdist = depth;
+    for (ui32 hdist = 0; hdist <= max_hdist; ++hdist) {
       // The case might be that we have already initialized this hdist, 
       // so we recompute since each time the depth increases new options emerge.
       if (LSHHashMap<D>::masks.size() > hdist) 
@@ -72,9 +73,9 @@ public:
     
     this->number_virtual_buckets = 1ULL << this->hashes.size();
 
-    if (LSHHashMap<D>::masks.size() < this->depth() + 1)
+    if (LSHHashMap<D>::masks.empty())
     {
-      LSHHashMap<D>::initMasks(this->depth());
+      LSHHashMap<D>::initMasks(32U, 4U);
     }
   }
 

--- a/src/index/lshhashmap.hpp
+++ b/src/index/lshhashmap.hpp
@@ -7,9 +7,16 @@ class LSHHashMap : public LSHMap<D> {
   // all possible masks by hamming distance 
   static inline std::vector<std::vector<ui32>> masks = std::vector<std::vector<ui32>>();
   
-  void initMasks() {
+
+public:
+  LSHHashMap(HashFamily<D>& hf) : LSHMap<D>(hf)
+  {
+    this->build(hf);
+  }
+
+  static void initMasks(ui32 depth) {
     ui32 constructed_masks = 0;
-    for (ui32 hdist = 0; hdist <= this->depth(); ++hdist) {
+    for (ui32 hdist = 0; hdist <= depth; ++hdist) {
       // The case might be that we have already initialized this hdist, 
       // so we recompute since each time the depth increases new options emerge.
       if (LSHHashMap<D>::masks.size() > hdist) 
@@ -20,7 +27,7 @@ class LSHHashMap : public LSHMap<D> {
       } 
 
       // Initalize a bitset of size depth with hdist bits set
-      std::vector<bool> vmask(this->depth(), false);
+      std::vector<bool> vmask(depth, false);
       
       // Set n first bits to true
       std::fill(vmask.begin(), vmask.begin() + hdist, true);
@@ -39,16 +46,10 @@ class LSHHashMap : public LSHMap<D> {
       constructed_masks += LSHHashMap<D>::masks[hdist].size();
     }
 
-    std::cout << "Masks size: " << this->masks.size() << std::endl
+    std::cout << "Masks size: " << LSHHashMap<D>::masks.size() << std::endl
               << "Total masks: " << constructed_masks << std::endl;
   }
-
-public:
-  LSHHashMap(HashFamily<D>& hf) : LSHMap<D>(hf)
-  {
-    this->build(hf);
-  }
-
+  
   /**
    * @brief Initialize this map with the given hashes. After this call, the map will be empty
    * @warning This will reset the map, and all points inserted will be lost
@@ -63,9 +64,9 @@ public:
     
     this->number_virtual_buckets = 1ULL << this->hashes.size();
 
-    if (masks.size() < this->depth() + 1)
+    if (LSHHashMap<D>::masks.size() < this->depth() + 1)
     {
-      initMasks();
+      LSHHashMap<D>::initMasks(this->depth());
     }
   }
 

--- a/src/index/lshhashmap.hpp
+++ b/src/index/lshhashmap.hpp
@@ -4,10 +4,19 @@
 
 template <ui32 D>
 class LSHHashMap : public LSHMap<D> {
+
 public:
   LSHHashMap(HashFamily<D>& hf) : LSHMap<D>(hf)
   {
     this->build(hf);
+  }
+  
+  /**
+   * @brief Return the number of points in the largest bucket in this map
+   *        The result is memoized, to avoid recalculating unnecessarily
+   */
+  ui32 maxBucketSize() {    
+    return max_bucket_size;
   }
 
   // all possible masks by hamming distance 
@@ -100,6 +109,9 @@ public:
     for (const auto& p : points) {
       this->add(p);
     }
+    for (const auto& [ _, b ] : this->buckets) {
+      this->max_bucket_size = std::max(this->max_bucket_size, (ui32) b.size());
+    }
   };
 
   /**
@@ -183,4 +195,5 @@ private:
   bucket empty_bucket;
   ui64 count;
   ui32 number_virtual_buckets;
+  ui32 max_bucket_size = 0; // number of points in largest bucket
 };

--- a/src/index/lshhashmap.hpp
+++ b/src/index/lshhashmap.hpp
@@ -4,15 +4,14 @@
 
 template <ui32 D>
 class LSHHashMap : public LSHMap<D> {
-  // all possible masks by hamming distance 
-  static inline std::vector<std::vector<ui32>> masks = std::vector<std::vector<ui32>>();
-  
-
 public:
   LSHHashMap(HashFamily<D>& hf) : LSHMap<D>(hf)
   {
     this->build(hf);
   }
+
+  // all possible masks by hamming distance 
+  static inline std::vector<std::vector<ui32>> masks = std::vector<std::vector<ui32>>();
 
   static void initMasks(ui32 depth) {
     ui32 constructed_masks = 0;

--- a/src/index/lshhashmap.hpp
+++ b/src/index/lshhashmap.hpp
@@ -16,7 +16,7 @@ public:
    *        The result is memoized, to avoid recalculating unnecessarily
    */
   ui32 maxBucketSize() {    
-    return max_bucket_size;
+    return this->max_bucket_size;
   }
 
   // all possible masks by hamming distance 
@@ -195,5 +195,4 @@ private:
   bucket empty_bucket;
   ui64 count;
   ui32 number_virtual_buckets;
-  ui32 max_bucket_size = 0; // number of points in largest bucket
 };

--- a/src/index/lshmap.hpp
+++ b/src/index/lshmap.hpp
@@ -15,6 +15,11 @@ public:
   LSHMap(HashFamily<D>& hashFamily) : hashes(hashFamily) {}
 
   virtual void build(HashFamily<D>& hashFamily) = 0;
+  
+  /**
+   * @returns Returns the maximum number of points that is stored in any bucket
+   */
+  virtual ui32 maxBucketSize() = 0;
 
   /**
    * @returns Number of points in the map

--- a/src/index/lshmap.hpp
+++ b/src/index/lshmap.hpp
@@ -6,7 +6,6 @@
 typedef std::vector<ui32> bucket; // index bucket
 typedef ui32 hash_idx;
 
-//! Implement functions with const flag 
 template<ui32 D>
 class LSHMap {
 

--- a/src/index/lshmap.hpp
+++ b/src/index/lshmap.hpp
@@ -11,7 +11,8 @@ class LSHMap {
 
 public:
   HashFamily<D> hashes;
-
+  ui32 max_bucket_size = 0; // number of points in largest bucket
+  
   LSHMap(HashFamily<D>& hashFamily) : hashes(hashFamily) {}
 
   virtual void build(HashFamily<D>& hashFamily) = 0;

--- a/src/index/lshmapfactory.hpp
+++ b/src/index/lshmapfactory.hpp
@@ -141,6 +141,7 @@ public:
     for (int i = 0; i < THREAD_CNT; ++i) {
       pool[i] = std::thread(build_map, i);
     }
+    
     // wait for threads to finish
     for (auto& th : pool) {
       th.join();

--- a/src/index/lshmapfactory.hpp
+++ b/src/index/lshmapfactory.hpp
@@ -103,4 +103,22 @@ public:
 
     return ret;
   }
+  /**
+   * @brief Construct @k LSHMaps with @depth hashfunctions chosen from @H
+   *        The hash functions are chosen to minimize the size of the largest bucket
+   *        and the building process is handled by multiple threads
+  */
+  static std::vector<LSHMap<D> *> mthread_create_optimized(
+    std::vector<Point<D>> &points, 
+    HashFamily<D> &H, 
+    ui32 depth, 
+    ui32 k, 
+    ui32 steps = 1) 
+  {
+    // https://www.educba.com/c-plus-plus-thread-pool/
+    const THREAD_CNT = std::thread::hardware_concurrency();
+    std::thread_pool pool(THREAD_CNT);
+
+    return std::vector<LSHMap<D> *>();
+  }
 };

--- a/src/index/lshmapfactory.hpp
+++ b/src/index/lshmapfactory.hpp
@@ -116,13 +116,9 @@ public:
     ui32 k, 
     ui32 steps = 1) 
   {
-    // Make sure to initialize the masks before starting threads
-    LSHHashMap<D>::initMasks(depth);
     
     const ui32 THREAD_CNT = std::thread::hardware_concurrency();
     const ui32 THREAD_STEPS = std::ceil(k * steps / ((double) THREAD_CNT));
-    assert(THREAD_CNT * steps >= k); 
-    
     LSHMapPriorityQueue<D> mqueue(H, k, depth);
 
     // Each thread builds @THREAD_STEPS LSHMaps from @points
@@ -136,13 +132,10 @@ public:
         map->build(hsubset); // Clears the map and builds it with the new hash family
         map->add(points);
         mqueue.push(map); // Attempt to push the map into the priority queue
-
-        //! comment line above and uncomment this to see it works:
-        //! if (mqueue.push(map)) std::cout << "Thread " << id << " found a new map at step " << i << std::endl;
       }
       delete map;
     };
-    
+
     // spawn threads that build_map
     std::vector<std::thread> pool(THREAD_CNT);
     for (int i = 0; i < THREAD_CNT; ++i) {

--- a/src/index/lshmapprioqueue.hpp
+++ b/src/index/lshmapprioqueue.hpp
@@ -13,65 +13,67 @@ template<ui32 D>
 class LSHMapBucketSizeCompare {
   public:
     bool operator()(LSHMap<D>* lhs, LSHMap<D>* rhs) const {
-      return lhs->maxBucketSize() < rhs->maxBucketSize();
+      return lhs->maxBucketSize() > rhs->maxBucketSize();
     }
 };
 
-// Thread safe priority queue for LSHMaps, ordering them by the size of their largest bucket
+/**
+ * @brief Thread safe priority queue for LSHMaps, ordering them by the size of their largest bucket.
+ *        Internally stores the maps in a Vector sorted by LSHMapBucketSize comparison such that front 
+ *        is map with largest bucket. An advantage of using a vector instead of the std::priority_queue,
+ *        is that get_all is non-destructive.
+ *        To avoid memory leaks the queue never copies the points from the maps that are pushed to the queue,
+ *        but only shallow copies the max_bucket_size and hashes.
+ */
 template<ui32 D>
 class LSHMapPriorityQueue {
-  // Underlying queue
-  std::priority_queue<LSHMap<D>*, std::vector<LSHMap<D>*>, LSHMapBucketSizeCompare<D>> pqueue;
+  std::vector<LSHMap<D>*> pqueue;
 
   // mutex for thread synchronization
   std::mutex mtx;
   
   // Maximum number of elements in the queue
-  ui32 max_size;
+  ui32 max_size, sz;
 
 public:
-  LSHMapPriorityQueue(ui32 max_size = 10) : max_size(max_size) {}
+  LSHMapPriorityQueue(HashFamily<D>& hf, ui32 max_size = 10, ui32 depth = 5) : max_size(max_size), sz(0) {
+    // Initialize queue with max_size maps
+    for (ui32 i = 0; i < max_size; ++i) {
+      HashFamily<D> hashes = hf.subset(depth); 
+      LSHMap<D>* mp = new LSHHashMap<D>(hashes);
+      mp->max_bucket_size = UINT32_MAX;
+      pqueue.push_back(mp);
+    }
+  }
+  ui32 capacity() const { return max_size; }
+  ui32 size() const { return sz; }
 
-  bool empty() const { return pqueue.empty(); }
+  // top of queue always points to the map with most points in it's largest bucket
+  LSHMap<D>* top() const { return pqueue.front(); }
+
+  bool empty() const { return sz == 0; }
 
   /**
-   * @brief Get all elements in the queue, emptying it in the process
+   * @brief Get all elements in the queue
   */
   std::vector<LSHMap<D>*> get_all() {
     std::unique_lock<std::mutex> lock(mtx);
-    std::vector<LSHMap<D>*> ret;
-    while (!pqueue.empty()) {
-      ret.emplace_back(pqueue.top());
-      pqueue.pop();
-    }
-    return ret;
+    return pqueue;
   }
-
-  // top of queue always points the map with most points in it's largest bucket
-  LSHMap<D>* top() const { return pqueue.top(); }
   
   bool push(LSHMap<D>* mp) {
     // Acquire an unique lock for the queue
     std::unique_lock<std::mutex> lock(mtx);
 
-    // If the queue is not full, push the map
-    if (pqueue.size() < this->max_size) {
-      pqueue.push(mp);
-      return true;
-    }
-
     // If the queue is full, check if the top element has a larger bucket than the map to be pushed
     bool hasPushed = false;
-    const ui32 topSize = pqueue.top()->maxBucketSize(),
-               mpSize = mp->maxBucketSize();
-    std::cout << "Queue is full, checking if top element has larger bucket than map to be pushed\n"
-              << "Top element has bucket size " << topSize << ", map to be pushed has bucket size " << mpSize << "\n"
-              << std::endl;
-    if (topSize > mpSize)
+    if (pqueue[0]->maxBucketSize() > mp->maxBucketSize())
     {
-      delete (pqueue.top());
-      pqueue.pop();
-      pqueue.push(mp);
+      pqueue[0]->max_bucket_size = mp->maxBucketSize();
+      pqueue[0]->build(mp->hashes);
+      if (sz < max_size) ++sz;
+      
+      std::sort(ALL(pqueue), LSHMapBucketSizeCompare<D>());
       hasPushed = true;
     }
 

--- a/src/index/lshmapprioqueue.hpp
+++ b/src/index/lshmapprioqueue.hpp
@@ -69,6 +69,7 @@ public:
     bool hasPushed = false;
     if (pqueue[0]->maxBucketSize() > mp->maxBucketSize())
     {
+      std::cout << "Pushing map with max bucket size " << mp->maxBucketSize() <<  " < " << pqueue[0]->maxBucketSize()<< std::endl;
       pqueue[0]->max_bucket_size = mp->maxBucketSize();
       pqueue[0]->build(mp->hashes);
       if (sz < max_size) ++sz;

--- a/src/index/lshmapprioqueue.hpp
+++ b/src/index/lshmapprioqueue.hpp
@@ -9,16 +9,11 @@
 #include <mutex>
 #include <condition_variable>
 
-static ui32 maxBucketSize(LSHMap<D>* mp) {
-  auto sizes = mp->get_bucket_sizes();
-  return sizes.empty() ? 0 : *std::max_element(ALL(sizes));
-}
-
 template<ui32 D>
 class LSHMapBucketSizeCompare {
   public:
     bool operator()(LSHMap<D>* lhs, LSHMap<D>* rhs) const {
-      return maxBucketSize(lhs) < maxBucketSize(rhs);
+      return lhs->maxBucketSize() < rhs->maxBucketSize();
     }
 };
 
@@ -67,9 +62,11 @@ public:
 
     // If the queue is full, check if the top element has a larger bucket than the map to be pushed
     bool hasPushed = false;
-    const ui32 topSize = maxBucketSize(pqueue.top()),
-               mpSize = maxBucketSize(mp);
-
+    const ui32 topSize = pqueue.top()->maxBucketSize(),
+               mpSize = mp->maxBucketSize();
+    std::cout << "Queue is full, checking if top element has larger bucket than map to be pushed\n"
+              << "Top element has bucket size " << topSize << ", map to be pushed has bucket size " << mpSize << "\n"
+              << std::endl;
     if (topSize > mpSize)
     {
       delete (pqueue.top());

--- a/src/index/lshmapprioqueue.hpp
+++ b/src/index/lshmapprioqueue.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "../hash/hashfamily.hpp"
+#include "lsharraymap.hpp"
+#include "lshhashmap.hpp"
+#include "../statistics/lshmapanalyzer.hpp"
+#include "../util/ranges.hpp"
+
+#include <mutex>
+#include <condition_variable>
+
+template<ui32 D>
+class LSHMapBucketSizeCompare {
+  public:
+    bool operator()(LSHMap<D>* lhs, LSHMap<D>* rhs) const {
+      return std::max_element(ALL(lhs->get_bucket_sizes())) < std::max_element(ALL(rhs->get_bucket_sizes()));
+    }
+};
+
+// Thread safe priority queue for LSHMaps, ordering them by the size of their largest bucket
+template<ui32 D>
+class LSHMapPriorityQueue {
+  // Underlying queue
+  std::priority_queue<LSHMap<D>*, std::vector<LSHMap<D>*>, LSHMapBucketSizeCompare<D>> pqueue;
+
+  // mutex for thread synchronization
+  std::mutex mtx;
+
+  // Condition variable for signaling
+  std::condition_variable cond;
+
+public:
+  bool empty() const { return pqueue.empty(); }
+  
+  LSHMap<D>* top() const { return pqueue.top(); }
+  
+  void push(LSHMap<D>* lshmap) {
+    std::unique_lock<std::mutex> lock(mtx);
+    pqueue.push(lshmap);
+    cond.notify_one();
+  }
+  
+  void pop() {
+    std::unique_lock<std::mutex> lock(mtx);
+    
+    // await queue to not be empty
+    cond.wait(lock, [this]() { return !pqueue.empty(); }); 
+    
+    pqueue.pop();
+  }
+};

--- a/src/index/lshmapprioqueue.hpp
+++ b/src/index/lshmapprioqueue.hpp
@@ -72,6 +72,7 @@ public:
 
     if (topSize > mpSize)
     {
+      delete (pqueue.top());
       pqueue.pop();
       pqueue.push(mp);
       hasPushed = true;

--- a/src/index/lshmapprioqueue.hpp
+++ b/src/index/lshmapprioqueue.hpp
@@ -9,11 +9,16 @@
 #include <mutex>
 #include <condition_variable>
 
+static ui32 maxBucketSize(LSHMap<D>* mp) {
+  auto sizes = mp->get_bucket_sizes();
+  return sizes.empty() ? 0 : *std::max_element(ALL(sizes));
+}
+
 template<ui32 D>
 class LSHMapBucketSizeCompare {
   public:
     bool operator()(LSHMap<D>* lhs, LSHMap<D>* rhs) const {
-      return std::max_element(ALL(lhs->get_bucket_sizes())) < std::max_element(ALL(rhs->get_bucket_sizes()));
+      return maxBucketSize(lhs) < maxBucketSize(rhs);
     }
 };
 
@@ -25,27 +30,53 @@ class LSHMapPriorityQueue {
 
   // mutex for thread synchronization
   std::mutex mtx;
-
-  // Condition variable for signaling
-  std::condition_variable cond;
+  
+  // Maximum number of elements in the queue
+  ui32 max_size;
 
 public:
+  LSHMapPriorityQueue(ui32 max_size = 10) : max_size(max_size) {}
+
   bool empty() const { return pqueue.empty(); }
-  
+
+  /**
+   * @brief Get all elements in the queue, emptying it in the process
+  */
+  std::vector<LSHMap<D>*> get_all() {
+    std::unique_lock<std::mutex> lock(mtx);
+    std::vector<LSHMap<D>*> ret;
+    while (!pqueue.empty()) {
+      ret.emplace_back(pqueue.top());
+      pqueue.pop();
+    }
+    return ret;
+  }
+
+  // top of queue always points the map with most points in it's largest bucket
   LSHMap<D>* top() const { return pqueue.top(); }
   
-  void push(LSHMap<D>* lshmap) {
+  bool push(LSHMap<D>* mp) {
+    // Acquire an unique lock for the queue
     std::unique_lock<std::mutex> lock(mtx);
-    pqueue.push(lshmap);
-    cond.notify_one();
-  }
-  
-  void pop() {
-    std::unique_lock<std::mutex> lock(mtx);
-    
-    // await queue to not be empty
-    cond.wait(lock, [this]() { return !pqueue.empty(); }); 
-    
-    pqueue.pop();
+
+    // If the queue is not full, push the map
+    if (pqueue.size() < this->max_size) {
+      pqueue.push(mp);
+      return true;
+    }
+
+    // If the queue is full, check if the top element has a larger bucket than the map to be pushed
+    bool hasPushed = false;
+    const ui32 topSize = maxBucketSize(pqueue.top()),
+               mpSize = maxBucketSize(mp);
+
+    if (topSize > mpSize)
+    {
+      pqueue.pop();
+      pqueue.push(mp);
+      hasPushed = true;
+    }
+
+    return hasPushed;
   }
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ int main()
   HashFamily<D> pool = HashFamilyFactory<D>::createRandomBitsConcat(D);
 
   std::cout << "[+] Loading Index..." << std::endl;
-  auto maps = LSHMapFactory<D>::create_optimized(dataset, pool, depth, count);
+  auto maps = LSHMapFactory<D>::mthread_create_optimized(dataset, pool, depth, count, 3);
 
   std::cout << "Building index" << std::endl;
   LSHForest<D> index(maps, dataset, SingleBitFailure<D>);

--- a/src/test/index/lshforest.cc
+++ b/src/test/index/lshforest.cc
@@ -44,6 +44,7 @@ TEST(LSHForestBuild, BuildInsertPointsIntoAllMaps) {
 
 // Expect excatly K results and correct distance
 TEST(LSHForestQuery, QueryReturnsCorrectResults) {
+  LSHHashMap<D>::masks = std::vector<std::vector<ui32>>();
   // Arrange : Build all maps on all combinations of points  
   std::vector<LSHMap<D>*> maps = LSHMapFactory<D>::create(H, 2, 2);
   std::vector<Point<D>> points = createCompleteInput();

--- a/src/test/index/lshmapfactory.cc
+++ b/src/test/index/lshmapfactory.cc
@@ -16,3 +16,11 @@ TEST(LSHMapFactoryInit, CanCreateMultipleMaps) {
   ASSERT_EQ(maps.size(), k);
   ASSERT_EQ(maps.front()->depth(), 1);
 }
+
+TEST(LSHMapFactoryThreadedTrieRebuilding, ReturnsExcatlyKMaps) {
+  const int k = 4, steps = 3;
+  auto points = createCompleteInput();
+  std::vector<LSHMap<D> *> maps = LSHMapFactory<D>::mthread_create_optimized(points, H, 1, k, steps);
+  ASSERT_EQ(maps.size(), k);
+  ASSERT_EQ(maps.front()->depth(), 1);
+}

--- a/src/test/index/lshmapprioqueue.cc
+++ b/src/test/index/lshmapprioqueue.cc
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+
+#include "util.hpp"
+#include "../../index/lshmap.hpp"
+#include "../../index/lshmapfactory.hpp"
+#include "../../index/lshmapprioqueue.hpp"
+
+TEST(LSHMapPriorityQueue, CanPushAndPop) {
+  LSHMapPriorityQueue<4> queue;
+
+  LSHMap<4>* map = LSHMapFactory<4>::create(H, 1);
+  
+  queue.push(map);
+  ASSERT_FALSE(queue.empty());
+
+  queue.pop();
+  ASSERT_TRUE(queue.empty());
+}
+
+TEST(LSHMapPriorityQueue, OrdersMapsByTheNumberOfPointsInLargestBucket) {
+  LSHMapPriorityQueue<4> queue;
+  
+  LSHMap<4> *map1 = LSHMapFactory<4>::create(H, 3),
+            *map2 = LSHMapFactory<4>::create(H, 3);
+
+  std::vector<Point<D>> points = {
+      Point<D>(0b0000),
+      Point<D>(0b0010),
+      Point<D>(0b0100),
+      Point<D>(0b0110),
+      Point<D>(0b1000),
+  };
+
+  map1->add(points);
+
+  queue.push(map1);
+  queue.push(map2);
+  
+  // Expect the one with most points in the largest bucket to be top
+  ASSERT_EQ(queue.top()->size(), map1->size()); 
+  queue.pop();
+
+  ASSERT_EQ(queue.top()->size(), map2->size());
+  queue.pop();
+  
+  ASSERT_TRUE(queue.empty());
+}

--- a/src/test/index/lshmapprioqueue.cc
+++ b/src/test/index/lshmapprioqueue.cc
@@ -5,7 +5,7 @@
 #include "../../index/lshmapfactory.hpp"
 
 TEST(LSHMapPriorityQueue, CanPush) {
-  LSHMapPriorityQueue<4> queue;
+  LSHMapPriorityQueue<4> queue(H, 1, 1);
 
   LSHMap<4>* map = LSHMapFactory<4>::create(H, 1);
   
@@ -13,23 +13,34 @@ TEST(LSHMapPriorityQueue, CanPush) {
   ASSERT_FALSE(queue.empty());
 }
 
-TEST(LSHMapPriorityQueue, GetAllEmptiesQueue) {
-  LSHMapPriorityQueue<4> queue;
-  LSHMap<4>* map = LSHMapFactory<4>::create(H, 1);
-
-  queue.push(map);
-  ASSERT_FALSE(queue.empty());
-  
-  std::vector<LSHMap<4>*> maps = queue.get_all();
+TEST(LSHMapPriorityQueue, QueueIsInitiallyEmpty) {
+  const ui32 k = 2, depth = 1;
+  LSHMapPriorityQueue<4> queue(H, k, depth);
   ASSERT_TRUE(queue.empty());
 }
 
-TEST(LSHMapPriorityQueue, PushDoesNotAddMap_IfFullAndMorePointsInLargestBucket) {
-  LSHMapPriorityQueue<4> queue(2);
+TEST(LSHMapPriorityQueue, GetAllReturnsMaxSizeMaps) {
+  const ui32 k = 2, depth = 1;
+  LSHMapPriorityQueue<4> queue(H, k, depth);
+  LSHMap<4>* m1 = LSHMapFactory<4>::create(H, depth),
+           * m2 = LSHMapFactory<4>::create(H, depth);
+
+  queue.push(m1);
+  queue.push(m2);
+  ASSERT_FALSE(queue.empty());
   
-  LSHMap<4> *empty1 = LSHMapFactory<4>::create(H, 3),
-            *empty2 = LSHMapFactory<4>::create(H, 3),
-            *mp = LSHMapFactory<4>::create(H, 3);
+  std::vector<LSHMap<4>*> maps = queue.get_all();
+  ASSERT_EQ(maps.size(), k);
+}
+
+TEST(LSHMapPriorityQueue, PushDoesNotAddMap_IfFullAndMorePointsInLargestBucket) {
+  const ui32 k = 2, depth = 3;
+
+  LSHMapPriorityQueue<4> queue(H, k, depth);
+  
+  LSHMap<4> *empty1 = LSHMapFactory<4>::create(H, depth),
+            *empty2 = LSHMapFactory<4>::create(H, depth),
+            *mp = LSHMapFactory<4>::create(H, depth);
 
   std::vector<Point<D>> points = {
       Point<D>(0b0000),
@@ -47,7 +58,7 @@ TEST(LSHMapPriorityQueue, PushDoesNotAddMap_IfFullAndMorePointsInLargestBucket) 
 }
 
 TEST(LSHMapPriorityQueue, OrdersMapsByTheNumberOfPointsInLargestBucket) {
-  LSHMapPriorityQueue<4> queue;
+  LSHMapPriorityQueue<4> queue(H, 2, 3);
   
   LSHMap<4> *map1 = LSHMapFactory<4>::create(H, 3),
             *map2 = LSHMapFactory<4>::create(H, 3);
@@ -64,5 +75,5 @@ TEST(LSHMapPriorityQueue, OrdersMapsByTheNumberOfPointsInLargestBucket) {
   ASSERT_TRUE(queue.push(map1));  
   ASSERT_TRUE(queue.push(map2));
   // Expect the one with most points in the largest bucket to be top
-  ASSERT_EQ(queue.top()->size(), map1->size());
+  ASSERT_EQ(queue.top()->maxBucketSize(), map1->maxBucketSize());
 }

--- a/src/test/index/lshmapprioqueue.cc
+++ b/src/test/index/lshmapprioqueue.cc
@@ -3,18 +3,47 @@
 #include "util.hpp"
 #include "../../index/lshmap.hpp"
 #include "../../index/lshmapfactory.hpp"
-#include "../../index/lshmapprioqueue.hpp"
 
-TEST(LSHMapPriorityQueue, CanPushAndPop) {
+TEST(LSHMapPriorityQueue, CanPush) {
   LSHMapPriorityQueue<4> queue;
 
   LSHMap<4>* map = LSHMapFactory<4>::create(H, 1);
   
   queue.push(map);
   ASSERT_FALSE(queue.empty());
+}
 
-  queue.pop();
+TEST(LSHMapPriorityQueue, GetAllEmptiesQueue) {
+  LSHMapPriorityQueue<4> queue;
+  LSHMap<4>* map = LSHMapFactory<4>::create(H, 1);
+
+  queue.push(map);
+  ASSERT_FALSE(queue.empty());
+  
+  std::vector<LSHMap<4>*> maps = queue.get_all();
   ASSERT_TRUE(queue.empty());
+}
+
+TEST(LSHMapPriorityQueue, PushDoesNotAddMap_IfFullAndMorePointsInLargestBucket) {
+  LSHMapPriorityQueue<4> queue(2);
+  
+  LSHMap<4> *empty1 = LSHMapFactory<4>::create(H, 3),
+            *empty2 = LSHMapFactory<4>::create(H, 3),
+            *mp = LSHMapFactory<4>::create(H, 3);
+
+  std::vector<Point<D>> points = {
+      Point<D>(0b0000),
+      Point<D>(0b0010),
+      Point<D>(0b0100),
+      Point<D>(0b0110),
+      Point<D>(0b1000),
+  };
+
+  mp->add(points);
+
+  ASSERT_TRUE(queue.push(empty1));
+  ASSERT_TRUE(queue.push(empty2));
+  ASSERT_FALSE(queue.push(mp)); // Should not be added
 }
 
 TEST(LSHMapPriorityQueue, OrdersMapsByTheNumberOfPointsInLargestBucket) {
@@ -32,16 +61,8 @@ TEST(LSHMapPriorityQueue, OrdersMapsByTheNumberOfPointsInLargestBucket) {
   };
 
   map1->add(points);
-
-  queue.push(map1);
-  queue.push(map2);
-  
+  ASSERT_TRUE(queue.push(map1));  
+  ASSERT_TRUE(queue.push(map2));
   // Expect the one with most points in the largest bucket to be top
-  ASSERT_EQ(queue.top()->size(), map1->size()); 
-  queue.pop();
-
-  ASSERT_EQ(queue.top()->size(), map2->size());
-  queue.pop();
-  
-  ASSERT_TRUE(queue.empty());
+  ASSERT_EQ(queue.top()->size(), map1->size());
 }


### PR DESCRIPTION
Fixes #60 Multithreaded trie-rebuilding

* There is now a higher risk of overtuning if too large values of @optimization_steps are chosen 
* I have manually tested to ensure there is no memory leak.
* The signature of the new rebuilding method LSHMapFactory<D>mthread_create_optimized matches the old LSHMapFactory<D>::create_optimized, to ensure backwards compatability.
* The commits also include an update to the work-flow ensuring that a faulty test will not be pushed.